### PR TITLE
Auth higher order component 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import MakeQuizPage from "./view/make-quiz/index";
 import QuizPage from "./view/quiz/index";
 import Layout from "./component/common/layout";
 import QuizBookListPage from "./view/quizbook-list";
+import Auth from "./component/common/auth";
 
 const App = () => {
   return (
@@ -19,7 +20,7 @@ const App = () => {
         <Route path="/login" component={LoginPage} />
         <Route path="/category/:categoryId" component={QuizBookListPage} />
         <Route path="/category" exact component={CategoryPage} />
-        <Route path="/profile" component={ProfilePage} />
+        <Route path="/profile" component={Auth(ProfilePage)} />
         <Route
           path="/quiz-book/:quizbookId/makequiz"
           component={MakeQuizPage}

--- a/src/common/lib/api/user.ts
+++ b/src/common/lib/api/user.ts
@@ -4,8 +4,7 @@ import axios from "../axios";
 
 const userAPI = {
   getUserInfo: async () => {
-    const userInfo = await axios.get<UserModel>(endpoints.USER_API);
-    console.log("실행");
+    const { data: userInfo } = await axios.get<UserModel>(endpoints.USER_API);
     return userInfo;
   },
 };

--- a/src/common/lib/axios.ts
+++ b/src/common/lib/axios.ts
@@ -10,7 +10,7 @@ const instance = axios.create({
 });
 
 instance.interceptors.response.use(
-  (response) => Promise.resolve(response.data),
+  (response) => Promise.resolve(response),
   (error) => Promise.reject(error)
 );
 

--- a/src/component/common/auth/index.tsx
+++ b/src/component/common/auth/index.tsx
@@ -1,21 +1,29 @@
 import React, { useEffect } from "react";
+import userAPI from "@/common/lib/api/user";
+import { insetUserInfo } from "@/modules/user";
 import { useCookies } from "react-cookie";
+import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 
 const Auth = (children: any) => {
+  const dispatch = useDispatch();
   const history = useHistory();
   const [authCookie] = useCookies(["accessToken"]);
 
-  console.log("auth");
   const checkUserLogin = async () => {
-    console.log(authCookie.email);
-    if (!authCookie.email) {
+    if (!authCookie) {
       history.push("/login");
+    } else {
+      try {
+        const userInfo = await userAPI.getUserInfo();
+        dispatch(insetUserInfo(userInfo));
+      } catch (e) {
+        history.push("/login");
+      }
     }
   };
 
   useEffect(() => {
-    console.log("실행");
     checkUserLogin();
   }, []);
 

--- a/src/modules/user/actions.ts
+++ b/src/modules/user/actions.ts
@@ -11,3 +11,8 @@ export const getUserInfoAsync = createAsyncAction(
   GET_USER_INFO_SUCCESS,
   GET_USER_INFO_ERROR
 )<undefined, UserModel, AxiosError>();
+
+export const insetUserInfo = (userInfo: UserModel) => ({
+  type: GET_USER_INFO_SUCCESS,
+  payload: userInfo,
+});


### PR DESCRIPTION
**변경사항**
- 기존의 axios 응답에서 data를 뽑아서 반환하였는데 typescript에서 이를 인식하지 못하여서 axios response 자체를 응답하는 식으로 변경 
- auth component 구현 
( auth 로 component로 감싸면 로그인이 안되어있을 경우 login page로 튕기는 역할)
- insert UserInfo 함수 구현
( 성공여부에 따라 redirect를 하기위하여 api를 직접 호출하여 user 정보를 가져오고 이를 집어넣기 위해 추가) 
- profile page auth component 로 감싸기 
(login을 하지 않고 프로필 페이지로 이동시 login page로 리다이렉트)


추후에 문제를 풀기 시작하는 페이지에도 auth component 로 감싸는 것 필요 
멤버가 아닌 경우 문제집 만들기에 접근하였을 경우 권한 없음을 나타내는 로직 추가 필요  