### PR TITLE
퀴즈북 페이지 무한스크롤 구현 

### DIFF
--- a/src/component/quizbook/index.tsx
+++ b/src/component/quizbook/index.tsx
@@ -7,97 +7,103 @@ import DropDown from "../drop-down";
 import { deleteQuizBookAsync } from "@/modules/user-quizbook";
 import { postQuizBookLikstAsync } from "@/modules/quiz-book";
 
-const QuizBook = ({ quizBook, isUserQuizBook }: QuizBookProps) => {
-  const likeButton = useRef<HTMLDivElement>(null);
-  const settingButton = useRef<HTMLImageElement>(null);
-  const dropDownContainer = useRef<HTMLDivElement>(null);
+// eslint-disable-next-line react/display-name
+const QuizBook = React.forwardRef(
+  (
+    { quizBook, isUserQuizBook }: QuizBookProps,
+    ref: React.Ref<HTMLDivElement>
+  ) => {
+    const likeButton = useRef<HTMLDivElement>(null);
+    const settingButton = useRef<HTMLImageElement>(null);
+    const dropDownContainer = useRef<HTMLDivElement>(null);
 
-  const [dropDown, setDropDown] = useState(false);
+    const [dropDown, setDropDown] = useState(false);
 
-  const history = useHistory();
-  const dispatch = useDispatch();
+    const history = useHistory();
+    const dispatch = useDispatch();
 
-  const onClick = (e) => {
-    if (e.target === likeButton.current) {
-      dispatch(postQuizBookLikstAsync.request(quizBook.id));
+    const onClick = (e) => {
+      if (e.target === likeButton.current) {
+        dispatch(postQuizBookLikstAsync.request(quizBook.id));
+        return;
+      }
+
+      if (e.target === settingButton.current) {
+        setDropDown(!dropDown);
+        return;
+      }
+
+      if (e.target.parentNode === dropDownContainer.current) {
+        return;
+      }
+
+      if (dropDown) {
+        setDropDown(!dropDown);
+        return;
+      }
+
+      history.push(`/quiz-book/${quizBook.id}/quiz`);
       return;
-    }
+    };
 
-    if (e.target === settingButton.current) {
-      setDropDown(!dropDown);
-      return;
-    }
+    const editQuizBook = () => {
+      history.push(`/addquiz`);
+      //TODO: 편집 문제 선택페이지
+    };
 
-    if (e.target.parentNode === dropDownContainer.current) {
-      return;
-    }
+    const deleteQuizBook = () => {
+      const isDelete = confirm(
+        "삭제 후 다시 복구할 수 없습니다. 정말 삭제하시겠어요?"
+      );
+      if (!isDelete) return;
 
-    if (dropDown) {
-      setDropDown(!dropDown);
-      return;
-    }
+      dispatch(deleteQuizBookAsync.request({ quizBookId: quizBook.id }));
+    };
 
-    history.push(`/quiz-book/${quizBook.id}/quiz`);
-    return;
-  };
+    return (
+      <S.QuizBookWrapper onClick={onClick} ref={ref}>
+        <S.QuizBookRow height={4}>
+          <S.QuizBookName>
+            <S.QuizBoldText>{quizBook.title}</S.QuizBoldText>
+          </S.QuizBookName>
+          <S.QuizBookLike>
+            <S.QuizText bold ref={likeButton}>
+              👍 {quizBook.likedCount}
+            </S.QuizText>
+          </S.QuizBookLike>
+        </S.QuizBookRow>
+        <S.QuizBookRow height={3}>
+          <S.QuizCount>
+            <S.QuizText bold>Q {quizBook.quizCount}</S.QuizText>
+          </S.QuizCount>
+          <S.SolvedCount>
+            <S.QuizText bold={false}>{quizBook.solvedCount} solve</S.QuizText>
+          </S.SolvedCount>
 
-  const editQuizBook = () => {
-    history.push(`/addquiz`);
-    //TODO: 편집 문제 선택페이지
-  };
-
-  const deleteQuizBook = () => {
-    const isDelete = confirm(
-      "삭제 후 다시 복구할 수 없습니다. 정말 삭제하시겠어요?"
+          <S.QuizBookOwner>
+            {!isUserQuizBook ? (
+              <S.QuizText bold={false}>{quizBook.ownerName}</S.QuizText>
+            ) : (
+              <>
+                <S.QuizBookSetButton
+                  src={"/src/asset/setting.png"}
+                  ref={settingButton}
+                />
+                <DropDown
+                  ref={dropDownContainer}
+                  show={dropDown}
+                  text1={"수정하기"}
+                  text2={"삭제하기"}
+                  clickEvent1={editQuizBook}
+                  clickEvent2={deleteQuizBook}
+                />
+              </>
+            )}
+          </S.QuizBookOwner>
+        </S.QuizBookRow>
+      </S.QuizBookWrapper>
     );
-    if (!isDelete) return;
-
-    dispatch(deleteQuizBookAsync.request({ quizBookId: quizBook.id }));
-  };
-
-  return (
-    <S.QuizBookWrapper onClick={onClick}>
-      <S.QuizBookRow height={4}>
-        <S.QuizBookName>
-          <S.QuizBoldText>{quizBook.title}</S.QuizBoldText>
-        </S.QuizBookName>
-        <S.QuizBookLike>
-          <S.QuizText bold ref={likeButton}>
-            👍 {quizBook.likedCount}
-          </S.QuizText>
-        </S.QuizBookLike>
-      </S.QuizBookRow>
-      <S.QuizBookRow height={3}>
-        <S.QuizCount>
-          <S.QuizText bold>Q {quizBook.quizCount}</S.QuizText>
-        </S.QuizCount>
-        <S.SolvedCount>
-          <S.QuizText bold={false}>{quizBook.solvedCount} solve</S.QuizText>
-        </S.SolvedCount>
-
-        <S.QuizBookOwner>
-          {!isUserQuizBook ? (
-            <S.QuizText bold={false}>{quizBook.ownerName}</S.QuizText>
-          ) : (
-            <>
-              <S.QuizBookSetButton
-                src={"/src/asset/setting.png"}
-                ref={settingButton}
-              />
-              <DropDown
-                ref={dropDownContainer}
-                show={dropDown}
-                text1={"수정하기"}
-                text2={"삭제하기"}
-                clickEvent1={editQuizBook}
-                clickEvent2={deleteQuizBook}
-              />
-            </>
-          )}
-        </S.QuizBookOwner>
-      </S.QuizBookRow>
-    </S.QuizBookWrapper>
-  );
-};
+  }
+);
 
 export default QuizBook;

--- a/src/container/quizbook-container/index.tsx
+++ b/src/container/quizbook-container/index.tsx
@@ -7,6 +7,7 @@ import { RootState } from "@/modules";
 import {
   getQuizBookListAsync,
   getUnsolvedQuizBookListAsync,
+  initQuizBookReducer,
   searchQuizBookListAsync,
 } from "@/modules/quiz-book";
 import * as S from "./styles";
@@ -18,9 +19,11 @@ const QuizBookContainer = ({ categoryId }: QuizBookContainerProps) => {
   const { data } = useSelector((state: RootState) => state.quizbook);
   const [unSolvedQuizBook, setUnSolvedQuizBook] = useState(false);
   const [isSortByDate, setIsSortByDate] = useState(true);
-  const [filter, setFilter] = useState("");
+  const [filter, setFilter] = useState<"all" | "unSolved">("all");
   const [show, setShow] = useState(false);
   const [keyword, setKeyword] = useState("");
+  const [page, setPage] = useState(1);
+  const target = useRef<HTMLDivElement>(null);
 
   const getQuizBookList = useCallback(
     (page) => {
@@ -47,19 +50,52 @@ const QuizBookContainer = ({ categoryId }: QuizBookContainerProps) => {
   }, [show]);
 
   const changeFilter = (e) => {
-    const filter = e.target.value;
-    if (filter === "all") setUnSolvedQuizBook(false);
-    if (filter === "unsolved") setUnSolvedQuizBook(true);
-    setFilter(filter);
+    const newFilter = e.target.value;
+    if (filter !== newFilter) {
+      dispatch(initQuizBookReducer());
+      setPage(1);
+      newFilter === "all"
+        ? setUnSolvedQuizBook(false)
+        : setUnSolvedQuizBook(true);
+      setFilter(newFilter);
+    }
   };
 
-  const searchQuizBookList = (keyword: string) => {
-    dispatch(searchQuizBookListAsync.request({ categoryId, keyword }));
-  };
+  const searchQuizBookList = useCallback(
+    (keyword: string) => {
+      dispatch(searchQuizBookListAsync.request({ categoryId, keyword }));
+    },
+    [keyword]
+  );
 
   useEffect(() => {
-    getQuizBookList(1);
-  }, [dispatch, unSolvedQuizBook, isSortByDate]);
+    let observer: IntersectionObserver;
+    if (target.current) {
+      observer = new IntersectionObserver(
+        (entries: IntersectionObserverEntry[]) => {
+          if (entries[0].intersectionRatio <= 0) return;
+          setPage(page + 1);
+        },
+        {
+          root: null,
+          rootMargin: "0px 0px 0px 10px",
+          threshold: 0.3,
+        }
+      );
+      observer.observe(target.current as Element);
+    }
+    return () => observer && observer.disconnect();
+  }, [data]);
+
+  useEffect(() => {
+    getQuizBookList(page);
+  }, [dispatch, unSolvedQuizBook, isSortByDate, page]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(initQuizBookReducer());
+    };
+  }, []);
 
   const delayedQueryCall = useRef(
     debounce((keyword: string) => searchQuizBookList(keyword), 500)
@@ -86,8 +122,8 @@ const QuizBookContainer = ({ categoryId }: QuizBookContainerProps) => {
         <S.ButtonFilter active={filter === "all"}>
           <S.FilterText value="all">전체 문제집</S.FilterText>
         </S.ButtonFilter>
-        <S.ButtonFilter active={filter === "unsolved"}>
-          <S.FilterText value="unsolved">안 푼 문제집</S.FilterText>
+        <S.ButtonFilter active={filter === "unSolved"}>
+          <S.FilterText value="unSolved">안 푼 문제집</S.FilterText>
         </S.ButtonFilter>
       </S.FilterColumn>
       <S.DropDownFilterContainer>
@@ -100,14 +136,28 @@ const QuizBookContainer = ({ categoryId }: QuizBookContainerProps) => {
           show={show}
           text1={"최신순"}
           text2={"인기순"}
-          clickEvent1={() => {
-            setIsSortByDate(true);
-            setShow(false);
-          }}
-          clickEvent2={() => {
-            setIsSortByDate(false);
-            setShow(false);
-          }}
+          clickEvent1={
+            isSortByDate
+              ? () => {
+                  setShow(false);
+                }
+              : () => {
+                  setPage(1);
+                  setIsSortByDate(true);
+                  dispatch(initQuizBookReducer());
+                }
+          }
+          clickEvent2={
+            isSortByDate
+              ? () => {
+                  setPage(1);
+                  setIsSortByDate(false);
+                  dispatch(initQuizBookReducer());
+                }
+              : () => {
+                  setShow(false);
+                }
+          }
         />
       </S.DropDownFilterContainer>
 
@@ -118,6 +168,7 @@ const QuizBookContainer = ({ categoryId }: QuizBookContainerProps) => {
               key={`quiz${quizBook.id}`}
               quizBook={quizBook}
               isUserQuizBook={false}
+              ref={target}
             ></QuizBook>
           );
         })}

--- a/src/container/quizbook-container/index.tsx
+++ b/src/container/quizbook-container/index.tsx
@@ -19,7 +19,6 @@ const QuizBookContainer = ({ categoryId }: QuizBookContainerProps) => {
   const { data } = useSelector((state: RootState) => state.quizbook);
   const [unSolvedQuizBook, setUnSolvedQuizBook] = useState(false);
   const [isSortByDate, setIsSortByDate] = useState(true);
-  const [filter, setFilter] = useState<"all" | "unSolved">("all");
   const [show, setShow] = useState(false);
   const [keyword, setKeyword] = useState("");
   const [page, setPage] = useState(1);
@@ -50,14 +49,14 @@ const QuizBookContainer = ({ categoryId }: QuizBookContainerProps) => {
   }, [show]);
 
   const changeFilter = (e) => {
-    const newFilter = e.target.value;
-    if (filter !== newFilter) {
+    const newFilter = Boolean(e.target.value);
+    if (unSolvedQuizBook !== newFilter) {
       dispatch(initQuizBookReducer());
       setPage(1);
-      newFilter === "all"
+      newFilter === false
         ? setUnSolvedQuizBook(false)
         : setUnSolvedQuizBook(true);
-      setFilter(newFilter);
+      setUnSolvedQuizBook(newFilter);
     }
   };
 
@@ -119,11 +118,11 @@ const QuizBookContainer = ({ categoryId }: QuizBookContainerProps) => {
         </S.CommonButtonWrapper>
       </S.SearchColumn>
       <S.FilterColumn align={"flex-start"} onClick={changeFilter}>
-        <S.ButtonFilter active={filter === "all"}>
-          <S.FilterText value="all">전체 문제집</S.FilterText>
+        <S.ButtonFilter active={unSolvedQuizBook === false}>
+          <S.FilterText value={""}>전체 문제집</S.FilterText>
         </S.ButtonFilter>
-        <S.ButtonFilter active={filter === "unSolved"}>
-          <S.FilterText value="unSolved">안 푼 문제집</S.FilterText>
+        <S.ButtonFilter active={unSolvedQuizBook === true}>
+          <S.FilterText value={1}>안 푼 문제집</S.FilterText>
         </S.ButtonFilter>
       </S.FilterColumn>
       <S.DropDownFilterContainer>

--- a/src/container/quizbook-container/styles.ts
+++ b/src/container/quizbook-container/styles.ts
@@ -38,7 +38,6 @@ interface QuizBookProps {
 
 export const ButtonFilter = styled.div<QuizBookProps>`
   width: auto;
-  padding: 0.5rem 1rem;
   height: 3rem;
   background-color: ${(props) => (props.active ? "#d77e6a" : "#ffa18c")};
   align-items: center;
@@ -60,6 +59,8 @@ export const Filter = styled.div`
 `;
 
 export const FilterText = styled.option`
+  padding: 0.5rem 1rem;
+
   text-align: center;
   font-size: 1.5rem;
 `;

--- a/src/modules/quiz-book/actions.ts
+++ b/src/modules/quiz-book/actions.ts
@@ -19,6 +19,8 @@ export const SEARCH_QUIZBOOK_LIST = "quizbook/SEARCH_QUIZBOOK_LIST" as const;
 export const SEARCH_QUIZBOOK_LIST_SUCCESS = "quizbook/SEARCH_QUIZBOOK_LIST_SUCCESS" as const;
 export const SEARCH_QUIZBOOK_LIST_ERROR = "quizbook/SEARCH_QUIZBOOK_LIST_ERROR" as const;
 
+export const INIT_QUIZBOOK_REDUCER = "quizbook/INIT_QUIZBOOK_REDUCER" as const;
+
 export const getQuizBookListAsync = createAsyncAction(
   GET_QUIZBOOK_LIST,
   GET_QUIZBOOK_LIST_SUCCESS,
@@ -42,3 +44,7 @@ export const searchQuizBookListAsync = createAsyncAction(
   SEARCH_QUIZBOOK_LIST_SUCCESS,
   SEARCH_QUIZBOOK_LIST_ERROR
 )<SearchAPIPayload, QuizBookModel[], AxiosError>();
+
+export const initQuizBookReducer = () => ({
+  type: INIT_QUIZBOOK_REDUCER,
+});

--- a/src/modules/quiz-book/reducer.ts
+++ b/src/modules/quiz-book/reducer.ts
@@ -1,5 +1,5 @@
-import { action, createReducer } from "typesafe-actions";
-import { SHOW_ALERT_MODAL } from "../modal";
+import QuizBookModel from "@/common/model/quiz-book";
+import { createReducer } from "typesafe-actions";
 import {
   GET_QUIZBOOK_LIST,
   GET_QUIZBOOK_LIST_ERROR,
@@ -7,6 +7,7 @@ import {
   GET_UNSOLVED_QUIZBOOK_LIST,
   GET_UNSOLVED_QUIZBOOK_LIST_ERROR,
   GET_UNSOLVED_QUIZBOOK_LIST_SUCCESS,
+  INIT_QUIZBOOK_REDUCER,
   POST_QUIZBOOK_LIKE,
   POST_QUIZBOOK_LIKe_ERROR,
   POST_QUIZBOOK_LIKE_SUCCESS,
@@ -21,38 +22,82 @@ const initialState: QuizBookState = {
   error: null,
   data: null,
   isUnsolved: false,
+  isSameCondition: false,
 };
 
 const quizBookReducer = createReducer<QuizBookState, QuizBookAction>(
   initialState,
   {
-    [GET_QUIZBOOK_LIST]: (state) => ({
-      ...state,
-      loading: true,
-      error: null,
-      isUnsolved: false,
-    }),
-    [GET_QUIZBOOK_LIST_SUCCESS]: (state, action) => ({
-      ...state,
-      loading: false,
-      data: action.payload,
-    }),
-    [GET_QUIZBOOK_LIST_ERROR]: (state, action) => ({
-      ...state,
-      loading: false,
-      error: action.payload,
-    }),
-    [GET_UNSOLVED_QUIZBOOK_LIST]: (state) => ({
-      ...state,
-      loading: true,
-      error: null,
-      isUnsolved: true,
-    }),
-    [GET_UNSOLVED_QUIZBOOK_LIST_SUCCESS]: (state, action) => ({
-      ...state,
-      loading: false,
-      data: action.payload,
-    }),
+    [INIT_QUIZBOOK_REDUCER]: () => initialState,
+    [GET_QUIZBOOK_LIST]: (state) => {
+      const { isUnsolved: previousState } = state;
+      return {
+        ...state,
+        loading: true,
+        error: null,
+        isUnsolved: false,
+        isSameCondition: previousState === false,
+      };
+    },
+    [GET_QUIZBOOK_LIST_SUCCESS]: (state, action) => {
+      const { isSameCondition, data: previousData } = state;
+      let mergedQuizBookList = [] as QuizBookModel[];
+
+      if (isSameCondition && previousData) {
+        mergedQuizBookList = [...previousData.concat(action.payload)];
+        return {
+          ...state,
+          loading: false,
+          data: mergedQuizBookList,
+          isSameCondition: false,
+        };
+      } else {
+        return {
+          ...state,
+          loading: false,
+          data: action.payload,
+          isSameCondition: false,
+        };
+      }
+    },
+    [GET_QUIZBOOK_LIST_ERROR]: (state, action) => {
+      return {
+        ...state,
+        loading: false,
+        error: action.payload,
+      };
+    },
+    [GET_UNSOLVED_QUIZBOOK_LIST]: (state) => {
+      const { isUnsolved: previousState } = state;
+      return {
+        ...state,
+        loading: true,
+        error: null,
+        isUnsolved: true,
+        isSameCondition: previousState === true,
+      };
+    },
+    [GET_UNSOLVED_QUIZBOOK_LIST_SUCCESS]: (state, action) => {
+      const { isSameCondition, data: previousData } = state;
+      let mergedQuizBookList = [] as QuizBookModel[];
+
+      if (isSameCondition && previousData) {
+        mergedQuizBookList = [...previousData.concat(action.payload)];
+        return {
+          ...state,
+          loading: false,
+          data: mergedQuizBookList,
+          isSameCondition: false,
+        };
+      } else {
+        return {
+          ...state,
+          loading: false,
+          data: action.payload,
+          isSameCondition: false,
+        };
+      }
+    },
     [GET_UNSOLVED_QUIZBOOK_LIST_ERROR]: (state, action) => ({
       ...state,
       loading: false,

--- a/src/modules/quiz-book/types.ts
+++ b/src/modules/quiz-book/types.ts
@@ -10,6 +10,7 @@ export type QuizBookState = {
   error: Error | null;
   data: QuizBookModel[] | null;
   isUnsolved: boolean;
+  isSameCondition: boolean;
 };
 
 export type QuizBookAPIPayload = {


### PR DESCRIPTION
- 퀴즈북 페이지 언마운트시 clean up 함수를  통해 quizbook store 상태 초기화
- 퀴즈북 컴포넌트 ref 인자 추가
- 퀴즈북 reducer 변경 ( 기존의 조건과 같은 조건으로 api 요청시 배열을 합치고, 아닌경우 새로 받아온 Payload만을 상태에 저장)
- 퀴즈북 페이지 intersection observer 추가 